### PR TITLE
Zoom pan

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 		<script src="js/connection.js" defer></script>
 		<script src="js/dot.js" defer></script>
 		<script src="js/physics.js" defer></script>
+		<script src="js/workspace.js" defer></script>
 		<script src="js/style.js" defer></script>
 		<script src="js/main.js" defer></script>
 		<meta name="viewport" content="width=device-width, user-scalable=no">
@@ -37,6 +38,6 @@
 					<ul><li>Start at output, drag to input</li></ul>
 			</ul>
 		</div>
-		<div id="workspace"></div>
+		<div id="workspaceWrapper"><div id="workspace"></div></div>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 		<script src="js/physics.js" defer></script>
 		<script src="js/style.js" defer></script>
 		<script src="js/main.js" defer></script>
-		<meta name="viewport" content="width=device-width, user-scalable=yes">
+		<meta name="viewport" content="width=device-width, user-scalable=no">
 	</head>
 	<body>
 		<img src="dotsynth_logo_white.png" id="logo">

--- a/index.html
+++ b/index.html
@@ -37,5 +37,6 @@
 					<ul><li>Start at output, drag to input</li></ul>
 			</ul>
 		</div>
+		<div id="workspace"></div>
 	</body>
 </html>

--- a/js/dot.js
+++ b/js/dot.js
@@ -5,7 +5,7 @@ var dotList = [];
 function Dot(definition, x, y) {
 	dotList.push(this);
 	var selfDot = this;
-	var parent = this.parentElement = document.body;
+	var parent = this.parentElement = DOT_CONTAINER;
 	this.definition = definition;
     this.definition.parent = selfDot;
 	this.connections = [];
@@ -207,7 +207,7 @@ function Dot(definition, x, y) {
 	addListeners(this.centerElement, {
 		onHoldStart: function(e) {navigator.vibrate(HOLD_EFFECT_VIBRATE_TIME);},
 		onHoldDragStart: function(e) {conn = new Connection(selfDot);},
-		onHoldDragMove: function(e) {conn.endAt(e.mmX, e.mmY)},
+		onHoldDragMove: function(e) {conn.endAt(e.mmX+pxToMm(DOT_CONTAINER.scrollLeft), e.mmY+pxToMm(DOT_CONTAINER.scrollTop))},
 		onDragStart: function(e) {
 			//move to front
 			selfDot.svgElement.parentNode.appendChild(selfDot.svgElement);
@@ -219,8 +219,8 @@ function Dot(definition, x, y) {
 		onDragMove: function(e) {
 			if (CONTINUOUS_PHYSICS)
 				Physics.remove(selfDot);
-			selfDot.x = e.mmX;
-			selfDot.y = e.mmY;
+			selfDot.x = e.mmX+pxToMm(DOT_CONTAINER.scrollLeft);
+			selfDot.y = e.mmY+pxToMm(DOT_CONTAINER.scrollTop);
 			if (CONTINUOUS_PHYSICS) {
 				Physics.add(selfDot);
 				updateArcsClipPath();

--- a/js/dot.js
+++ b/js/dot.js
@@ -207,7 +207,7 @@ function Dot(definition, x, y) {
 	addListeners(this.centerElement, {
 		onHoldStart: function(e) {navigator.vibrate(HOLD_EFFECT_VIBRATE_TIME);},
 		onHoldDragStart: function(e) {conn = new Connection(selfDot);},
-		onHoldDragMove: function(e) {conn.endAt(e.mmX+pxToMm(DOT_CONTAINER.scrollLeft), e.mmY+pxToMm(DOT_CONTAINER.scrollTop))},
+		onHoldDragMove: function(e) {conn.endAt(e.mmX, e.mmY)},
 		onDragStart: function(e) {
 			//move to front
 			selfDot.svgElement.parentNode.appendChild(selfDot.svgElement);
@@ -219,8 +219,8 @@ function Dot(definition, x, y) {
 		onDragMove: function(e) {
 			if (CONTINUOUS_PHYSICS)
 				Physics.remove(selfDot);
-			selfDot.x = e.mmX+pxToMm(DOT_CONTAINER.scrollLeft);
-			selfDot.y = e.mmY+pxToMm(DOT_CONTAINER.scrollTop);
+			selfDot.x = e.mmX;
+			selfDot.y = e.mmY;
 			if (CONTINUOUS_PHYSICS) {
 				Physics.add(selfDot);
 				updateArcsClipPath();
@@ -239,7 +239,7 @@ function Dot(definition, x, y) {
 			conn.finalize(document.elementFromPoint(e.clientX, e.clientY))
 		},
 		onTapEnd: function(e) {selfDot.toggle();}
-	});
+	}, true);
 	
 	function Arc(parent, start, end, definition) {
 		var selfArc = this;
@@ -418,10 +418,10 @@ function Dot(definition, x, y) {
 		
 		//arc events
 		addListeners(this.pathElement, {
-			onTapStart: function(e) {modifyValue(e.pxX + DOT_CONTAINER.scrollLeft, e.pxY + DOT_CONTAINER.scrollTop);},
-			onDragMove: function(e) {modifyValue(e.pxX + DOT_CONTAINER.scrollLeft, e.pxY + DOT_CONTAINER.scrollTop);},
-			onTapEnd:   function(e) {modifyValue(e.pxX + DOT_CONTAINER.scrollLeft, e.pxY + DOT_CONTAINER.scrollTop);}
-		});
+			onTapStart: function(e) {modifyValue(e.pxX, e.pxY);},
+			onDragMove: function(e) {modifyValue(e.pxX, e.pxY);},
+			onTapEnd:   function(e) {modifyValue(e.pxX, e.pxY);}
+		}, true);
 	}
 	Physics.add(this);
 	function updateArcsClipPath() {

--- a/js/dot.js
+++ b/js/dot.js
@@ -418,9 +418,9 @@ function Dot(definition, x, y) {
 		
 		//arc events
 		addListeners(this.pathElement, {
-			onTapStart: function(e) {modifyValue(e.pxX, e.pxY);},
-			onDragMove: function(e) {modifyValue(e.pxX, e.pxY);},
-			onTapEnd:   function(e) {modifyValue(e.pxX, e.pxY);}
+			onTapStart: function(e) {modifyValue(e.pxX + DOT_CONTAINER.scrollLeft, e.pxY + DOT_CONTAINER.scrollTop);},
+			onDragMove: function(e) {modifyValue(e.pxX + DOT_CONTAINER.scrollLeft, e.pxY + DOT_CONTAINER.scrollTop);},
+			onTapEnd:   function(e) {modifyValue(e.pxX + DOT_CONTAINER.scrollLeft, e.pxY + DOT_CONTAINER.scrollTop);}
 		});
 	}
 	Physics.add(this);

--- a/js/eventhelper.js
+++ b/js/eventhelper.js
@@ -33,6 +33,10 @@ function addListeners(element, listeners) {
 	var onHoldEnd = listeners.onHoldEnd;
 	var onDragEnd = listeners.onDragEnd;
 	var onHoldDragEnd = listeners.onHoldDragEnd;
+	
+	var allowScroll = !(onDragStart || onDragMove || onDragEnd)
+			&& !(onTapStart || onTapEnd);
+	
 	var self = this;
 	//keep track of when this object has focus;
 	//don't let multiple interactions happen at once.
@@ -105,7 +109,8 @@ function addListeners(element, listeners) {
 							if (onDragMove) onDragMove(returnEvent);
 						}
 					}
-					e.preventDefault();
+					if (hold || !allowScroll)
+						e.preventDefault();
 				}
 			}
 			function onTouchEnd(e) {
@@ -142,14 +147,16 @@ function addListeners(element, listeners) {
 					}
 					document.removeEventListener('touchmove', onTouchMove);
 					document.removeEventListener('touchend', onTouchEnd);
-					e.preventDefault();
+					if (hold || !allowScroll)
+						e.preventDefault();
 				}
 			}
 			document.addEventListener('touchmove', onTouchMove);
 			document.addEventListener('touchend', onTouchEnd);
 			//only stop propagation on interaction start (indicating that this event has been 'captured');
 			e.stopPropagation();
-			e.preventDefault();
+			if (!allowScroll)
+				e.preventDefault();
 		}
 	});
 	

--- a/js/eventhelper.js
+++ b/js/eventhelper.js
@@ -61,7 +61,8 @@ function addListeners(element, listeners, includeOffset, maxInteractions) {
 					mmY: pxToMm(targetTouch.pageY / (includeOffset ? scale : 1)) - (includeOffset ? offset.mmY / scale : 0),
 					clientX: targetTouch.clientX,
 					clientY: targetTouch.clientY,
-					interactions: interactions
+					interactions: interactions,
+					identifier: targetTouch.identifier
 				}
 				var touchId = targetTouch.identifier;
 				var initialPos = {
@@ -90,7 +91,8 @@ function addListeners(element, listeners, includeOffset, maxInteractions) {
 							pxDY: targetTouch.clientY - cy,
 							clientX: targetTouch.clientX,
 							clientY: targetTouch.clientY,
-							interactions: interactions
+							interactions: interactions,
+							identifier: targetTouch.identifier
 						}
 						cx = targetTouch.clientX;
 						cy = targetTouch.clientY;
@@ -139,7 +141,8 @@ function addListeners(element, listeners, includeOffset, maxInteractions) {
 							pxDY: targetTouch.clientY - cy,
 							clientX: targetTouch.clientX,
 							clientY: targetTouch.clientY,
-							interactions: interactions
+							interactions: interactions,
+							identifier: targetTouch.identifier
 						}
 						touchId = null;
 						clearTimeout(touchTime);
@@ -194,7 +197,8 @@ function addListeners(element, listeners, includeOffset, maxInteractions) {
 				mmY: pxToMm(e.pageY / (includeOffset ? scale : 1)) - (includeOffset ? offset.mmY / scale : 0),
 				clientX: e.clientX,
 				clientY: e.clientY,
-				interactions: interactions
+				interactions: interactions,
+				identifier: "cursor"
 			}
 			self.mouseIsDown = true;
 			var initialPos = {
@@ -220,7 +224,8 @@ function addListeners(element, listeners, includeOffset, maxInteractions) {
 					pxDY: e.clientY - cy,
 					clientX: e.clientX,
 					clientY: e.clientY,
-					interactions: interactions
+					interactions: interactions,
+					identifier: "cursor"
 				}
 				cx = e.clientX;
 				cy = e.clientY;
@@ -265,7 +270,8 @@ function addListeners(element, listeners, includeOffset, maxInteractions) {
 					pxDY: e.clientY - cy,
 					clientX: e.clientX,
 					clientY: e.clientY,
-					interactions: interactions
+					interactions: interactions,
+					identifier: "cursor"
 				}
 				self.mouseIsDown = false;
 				clearTimeout(touchTime);

--- a/js/globals.js
+++ b/js/globals.js
@@ -36,3 +36,5 @@ var GRID_SIZE = DOT_PHYSICS_RADIUS*1.4;
 
 var CONTINUOUS_PHYSICS = false;
 var nodeArray = [];
+
+var DOT_CONTAINER = document.getElementById('workspace');

--- a/js/globals.js
+++ b/js/globals.js
@@ -38,3 +38,4 @@ var CONTINUOUS_PHYSICS = false;
 var nodeArray = [];
 
 var DOT_CONTAINER = document.getElementById('workspace');
+var DOT_CONTAINER_WRAPPER = document.getElementById('workspaceWrapper');

--- a/js/newdotmenu.js
+++ b/js/newdotmenu.js
@@ -1,11 +1,11 @@
-addListeners(document, {onHoldStart: function(e) {
+addListeners(DOT_CONTAINER, {onHoldStart: function(e) {
 	var self = this;
 	this.isVisible = false;
 	if (this.newDotMenu == undefined) {
 		//first-time set-up
 		this.newDotMenu = document.createElementNS(NS, 'svg');
 		this.newDotMenu.classList.add('newDotMenu');
-		document.body.appendChild(this.newDotMenu);
+		DOT_CONTAINER.appendChild(this.newDotMenu);
 		//recreate this menu
 		var radius = layerRadius(DOT_LIST.length);
 		var size = (radius + DOT_RADIUS + GAP_WIDTH)*2;
@@ -39,7 +39,7 @@ addListeners(document, {onHoldStart: function(e) {
 			circle.setAttributeNS(null, 'fill', 'hsla(' + DOT_LIST[i].hue + ', 100%, ' + DOT_LIGHTNESS + ', 1)');
 			circle.dotDefinition = DOT_LIST[i];
 			addListeners(circle, {onTapStart: function(e) {
-				newDot = new Dot(e.element.dotDefinition, e.mmX, e.mmY);
+				newDot = new Dot(e.element.dotDefinition, e.mmX +pxToMm(DOT_CONTAINER.scrollLeft), e.mmY+pxToMm(DOT_CONTAINER.scrollTop));
 				nodeArray.push(newDot);
 				self.isVisible = false;
 				newDotMenu.classList.add('hidden');
@@ -56,8 +56,8 @@ addListeners(document, {onHoldStart: function(e) {
 		this.isVisible = true;
 		newDotMenu.classList.remove('hidden');
 		//TODO: make it show properly!
-		newDotMenu.style.left = e.pxX - newDotMenu.offsetWidth/2 + "px";
-		newDotMenu.style.top = e.pxY - newDotMenu.offsetHeight/2 + "px";
+		newDotMenu.style.left = e.pxX +DOT_CONTAINER.scrollLeft - newDotMenu.offsetWidth/2 + "px";
+		newDotMenu.style.top = e.pxY +DOT_CONTAINER.scrollTop - newDotMenu.offsetHeight/2 + "px";
 	}
 }});
 

--- a/js/newdotmenu.js
+++ b/js/newdotmenu.js
@@ -1,4 +1,4 @@
-addListeners(DOT_CONTAINER, {onHoldStart: function(e) {
+dotMenuEvent = function(e) {
 	var self = this;
 	this.isVisible = false;
 	if (this.newDotMenu == undefined) {
@@ -43,7 +43,7 @@ addListeners(DOT_CONTAINER, {onHoldStart: function(e) {
 				nodeArray.push(newDot);
 				self.isVisible = false;
 				newDotMenu.classList.add('hidden');
-			}});
+			}}, true);
 			newDotMenu.appendChild(circle);
 			newDotMenu.appendChild(name);
 		}
@@ -56,10 +56,10 @@ addListeners(DOT_CONTAINER, {onHoldStart: function(e) {
 		this.isVisible = true;
 		newDotMenu.classList.remove('hidden');
 		//TODO: make it show properly!
-		newDotMenu.style.left = e.pxX +DOT_CONTAINER.scrollLeft - newDotMenu.offsetWidth/2 + "px";
-		newDotMenu.style.top = e.pxY +DOT_CONTAINER.scrollTop - newDotMenu.offsetHeight/2 + "px";
+		newDotMenu.style.left = e.pxX - newDotMenu.offsetWidth/2 + "px";
+		newDotMenu.style.top = e.pxY - newDotMenu.offsetHeight/2 + "px";
 	}
-}});
+};
 
 /**
  * Helper function. Determines the ideal radius of a circle of dots

--- a/js/workspace.js
+++ b/js/workspace.js
@@ -1,0 +1,85 @@
+(function() {
+	function isSupported(property) {
+		return (property in document.body.style) ? property : undefined;
+	}
+	var transformProperty = isSupported('transform')
+			|| isSupported('-webkit-transform')
+			|| isSupported('-moz-transform')
+			|| isSupported('-ms-transform');
+		
+	var panning = false;
+	window.offset = {};
+	window.scale = 1;
+	var _x = 0;
+	var _y = 0;
+	Object.defineProperty(offset, 'pxX', {
+		get: function() {
+			return _x;
+		},
+		set: function(val) {
+			_x = val;
+			DOT_CONTAINER.style[transformProperty] = "translate(" + _x + "px," + _y + "px)";
+		}
+	});
+	Object.defineProperty(offset, 'pxY', {
+		get: function() {
+			return _y;
+		},
+		set: function(val) {
+			_y = val;
+			DOT_CONTAINER.style[transformProperty] = "translate(" + _x + "px," + _y + "px)";
+		}
+	});
+	Object.defineProperty(offset, 'mmX', {
+		get: function() {
+			return pxToMm(_x);
+		},
+		set: function(val) {
+			_x = mmToPx(val);
+			DOT_CONTAINER.style[transformProperty] = "translate(" + _x + "px," + _y + "px)";
+		}
+	});
+	Object.defineProperty(offset, 'mmY', {
+		get: function() {
+			return pxToMm(_y);
+		},
+		set: function(val) {
+			_y = mmToPx(val);
+			DOT_CONTAINER.style[transformProperty] = "translate(" + _x + "px," + _y + "px)";
+		}
+	});
+	addListeners(DOT_CONTAINER_WRAPPER, {
+		onTapStart: function(e) {
+		},
+		onDragStart: function(e) {
+			if (e.interactions == 1) {
+				panning = true;
+			}
+		},
+		onDragMove: function(e) {
+			if (panning) {
+				offset.pxX += e.pxDX/e.interactions;
+				offset.pxY += e.pxDY/e.interactions;
+			}
+		},
+		onHoldStart: function(e) {
+			if (!panning)
+				dotMenuEvent(e);
+		},
+		onTapEnd: function(e) {
+			if (e.interactions == 0) {
+				panning = false;
+			}
+		},
+		onHoldEnd: function(e) {
+			if (e.interactions == 0) {
+				panning = false;
+			}
+		},
+		onDragEnd: function(e) {
+			if (e.interactions == 0) {
+				panning = false;
+			}
+		}
+	}, true);
+})()

--- a/js/workspace.js
+++ b/js/workspace.js
@@ -17,6 +17,9 @@
 			return _scale;
 		},
 		set: function(val) {
+			var ratio = val/_scale;
+			offset.pxX += ((centerX-offset.pxX)/val - (centerX-offset.pxX)/_scale)*val;
+			offset.pxY += ((centerY-offset.pxY)/val - (centerY-offset.pxY)/_scale)*val;
 			_scale = val;
 			_redraw();
 		}

--- a/js/workspace.js
+++ b/js/workspace.js
@@ -78,8 +78,6 @@
 			if (panning) {
 				offset.pxX += e.pxDX/e.interactions;
 				offset.pxY += e.pxDY/e.interactions;
-				var centerWeight = (e.interactions-1)/e.interactions;
-				var newTouchWeight = 1/e.interactions;
 				if (e.interactions >= 2) {
 					var oldDistanceFromCenterX = e.clientX-e.pxDX-centerX;
 					var oldDistanceFromCenterY = e.clientY-e.pxDY-centerY;
@@ -92,9 +90,8 @@
 					var newDistanceFromCenterY = e.clientY-centerY;
 					var newDistanceFromCenter = Math.sqrt(Math.pow(newDistanceFromCenterX,2)+Math.pow(newDistanceFromCenterY,2));
 					var scaleFactor = (newDistanceFromCenter / oldDistanceFromCenter);
-					scaleFactor = (scaleFactor-1)*newTouchWeight+1;
+					scaleFactor = Math.pow(scaleFactor, 2/e.interactions);
 					scale *= scaleFactor;
-					help.innerHTML = scale.toFixed(3);
 				} else {
 					centerX = e.clientX;
 					centerY = e.clientY;

--- a/main.css
+++ b/main.css
@@ -24,6 +24,11 @@ body p {
     position: absolute;
     margin: 0 0 0 0;
 }
+#workspace {
+	position: absolute;
+	top: 0; left: 0; bottom: 0; right: 0;
+	overflow: scroll;
+}
 /*.oscTypeMenu {
 	position: absolute;
 	right: 2%;

--- a/main.css
+++ b/main.css
@@ -29,6 +29,12 @@ body p {
 	top: 0; left: 0; bottom: 0; right: 0;
 	overflow: hidden;
 }
+#workspace {
+	-webkit-transform-origin: 0;
+	-moz-transform-origin: 0;
+	-ms-transform-origin: 0;
+	transform-origin: 0;
+}
 /*.oscTypeMenu {
 	position: absolute;
 	right: 2%;

--- a/main.css
+++ b/main.css
@@ -24,10 +24,10 @@ body p {
     position: absolute;
     margin: 0 0 0 0;
 }
-#workspace {
+#workspaceWrapper {
 	position: absolute;
 	top: 0; left: 0; bottom: 0; right: 0;
-	overflow: scroll;
+	overflow: hidden;
 }
 /*.oscTypeMenu {
 	position: absolute;

--- a/main.css
+++ b/main.css
@@ -1,4 +1,8 @@
 @import url(http://fonts.googleapis.com/css?family=Open+Sans);
+html, body {
+	width: 100%;
+}
+
 body {
     font-family: 'Open Sans', sans-serif;
     margin: 0;


### PR DESCRIPTION
This branch fixes #9 #10 #11 . It required the addition of a global `offset` and `scale`, and the `DOT_CONTAINER` and `DOT_CONTAINER_WRAPPER`.

The native scrolling is not used. All scroll and zoom gestures are completely custom.

Modifications were made to `addListeners`. There are two more parameters, `includeOffset`, and `maxInteractions`.
- `includeOffset` - if true, all returned coordinates include the scale and offset transformations of the `DOT_CONTAINER`. By default, this value acts as `false`.
- `maxInteractions` - this is the maximum number of touches/pointers allowed on an element. So, something like an arc only can have one. But zooming has many. By default, this value is `1`.

Please review.
